### PR TITLE
Add example/demo/dev page

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,11 @@
+<html>
+    <head>
+        <title>react-flashcard Demo</title>
+    </head>
+
+    <body>
+        <div id="example"></div>
+    </body>
+
+    <script src="./index.tsx"></script>
+</html>

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { hydrate } from 'react-dom';
+
+import { Flashcard } from '../src/Flashcard';
+
+const Demo = () => (
+    <Flashcard />
+)
+
+hydrate(<Demo />, document.getElementById('example'));

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "parcel watch src/index.ts",
     "build": "parcel build src/index.ts --global react-flashcard",
+    "demo": "parcel example/index.html --out-dir examples/dist --open",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "David Futcher <david@futcher.io> & Roosa Paivansalo",
@@ -17,6 +18,7 @@
     "@types/react": "^16.0",
     "parcel-bundler": "^1.12.4",
     "react": "^16.0",
+    "react-dom": "^16.0",
     "typescript": "^4.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4203,6 +4203,16 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
+react-dom@^16.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
+  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
+
 react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -4454,6 +4464,14 @@ saxes@^3.1.9:
   integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
   dependencies:
     xmlchars "^2.1.1"
+
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 semver@7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Adds an example of how to use react-flashcard to `./examples`. The example can be run using `npm run demo`, which will open the example page in a browser. As well as being an example for future library users, it can equally be used for developing or locally testing the component.